### PR TITLE
Added License header keyword to library

### DIFF
--- a/iasm-mode.el
+++ b/iasm-mode.el
@@ -6,6 +6,7 @@
 ;; Created: 2013-09-29
 ;; Version: 0.1
 ;; Keywords:: tools
+;; License: BSD-2-clause
 ;; Url: https://github.com/RAttab/iasm-mode
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
I am the maintainer of the [Emacsmirror](https://emacsmirror.net) and have to make sure that the licenses of all mirrored packages are compatible with the GPLv3 used by Emacs.

This package is among the few that actually do specify the license that is expected to be detected by the tools that I use for that purpose, but for some reason that fails. I use some custom elisp to inspect the permission statement or License header keyword in the "main library". If that fails, I use the `licensee` tool to determine the license specified by the `LICENSE` (or similar) file. If that fails I use the Github API to detect to ask them what license they detected. They also use `licensee` for that purpose, but apparently they have changed its configuration because sometimes it works for them but not for me. The oddest case is when Github displays the license for a repository on the webpage, but over the API it claims that it was not able to detect the license. That's what is happening here.

This commit adds the License header keyword, to have something very easy to parse.

